### PR TITLE
fixed bug where tnx and utxo file was not being overwritten

### DIFF
--- a/src/persist/transaction.py
+++ b/src/persist/transaction.py
@@ -13,6 +13,8 @@ def save_verified_transaction(tnx_id, tnx_data):
         with open('{0}/verified_transactions.json'.format(os.path.join(os.getcwd(), r'data')), 'r+') as file:
             data = json.load(file)
             data.update(verified_tnx)
+
+            file.seek(0)
             json.dump(data, file)
             file.close()
     except IOError as e:
@@ -35,6 +37,8 @@ def save_unverified_transaction(tnx_id, tnx_data):
         with open('{0}/unverified_transactions.json'.format(os.path.join(os.getcwd(), r'data')), 'r+') as file:
             data = json.load(file)
             data.update([unverified_tnx])
+
+            file.seek(0)
             json.dump(data, file)
             file.close()
     except IOError as e:

--- a/src/persist/utxo.py
+++ b/src/persist/utxo.py
@@ -99,8 +99,9 @@ def save_utxo(transaction_id, output_index, block_hash, amount):
     try:
         with open(_PATH_UNSPENT_TNX, 'r+') as file:
             data = json.load(file)
-
             data.update(new_utxo)
+
+            file.seek(0)
             json.dump(data, file)
             file.close()
     except IOError:


### PR DESCRIPTION
whenever we open a file for read and write, whenever file is read the cursor is left at the end of the file. So when writing data, it's actually appending. `.seek()` allows us to move the cursor so I am using that to move the cursor back to the beginning of the file